### PR TITLE
[FET-625] Lock screen-orientation to portrait in android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
             android:name="com.modus.ishihara.app.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:screenOrientation="portrait">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@ionic-native/screenshot": "^5.36.0",
         "@stencil/store": "^1.5.0",
         "classnames": "^2.3.1",
-        "cordova-plugin-screen-orientation": "^3.0.2",
         "cordova-plugin-screenshot": "https://github.com/gitawego/cordova-screenshot.git"
       },
       "devDependencies": {
@@ -1855,18 +1854,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/cordova-plugin-screen-orientation": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-screen-orientation/-/cordova-plugin-screen-orientation-3.0.2.tgz",
-      "integrity": "sha512-2w6CMC+HGvbhogJetalwGurL2Fx8DQCCPy3wlSZHN1/W7WoQ5n9ujVozcoKrY4VaagK6bxrPFih+ElkO8Uqfzg==",
-      "engines": {
-        "cordovaDependencies": {
-          "4.0.0": {
-            "cordova": ">100"
-          }
-        }
       }
     },
     "node_modules/cordova-plugin-screenshot": {
@@ -6599,11 +6586,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "cordova-plugin-screen-orientation": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-screen-orientation/-/cordova-plugin-screen-orientation-3.0.2.tgz",
-      "integrity": "sha512-2w6CMC+HGvbhogJetalwGurL2Fx8DQCCPy3wlSZHN1/W7WoQ5n9ujVozcoKrY4VaagK6bxrPFih+ElkO8Uqfzg=="
     },
     "cordova-plugin-screenshot": {
       "version": "git+ssh://git@github.com/gitawego/cordova-screenshot.git#2f2d763e1df4752e51eec1db3b623d72043d90fb",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@ionic-native/screenshot": "^5.36.0",
     "@stencil/store": "^1.5.0",
     "classnames": "^2.3.1",
-    "cordova-plugin-screen-orientation": "^3.0.2",
     "cordova-plugin-screenshot": "https://github.com/gitawego/cordova-screenshot.git"
   }
 }

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -2,7 +2,6 @@ import { Component, h, State } from '@stencil/core';
 import { SplashScreen } from '@capacitor/splash-screen';
 import routes from '../helpers/routes';
 import { loadPlates } from '../helpers/utils';
-import { Capacitor } from '@capacitor/core';
 
 @Component({
   tag: 'app-root',
@@ -11,9 +10,6 @@ export class AppRoot {
   @State() hasBack: boolean = false;
 
   async componentWillLoad() {
-    if (Capacitor.getPlatform() === 'android') {
-      window.screen.orientation.lock('portrait');
-    }
     await loadPlates();
     await SplashScreen.hide();
   }


### PR DESCRIPTION
Resolution for **[FET-625](https://moduscreate.atlassian.net/browse/FET-625)**.

Upon android device testing, found orientation lock to be working only when mentioned within `AndroidManifest.xml`(contained within the platform folder). 

_NB:_ Tried [@ionic-native/screen-orientation](https://www.npmjs.com/package/@ionic-native/screen-orientation) and [cordova-plugin-screen-orientation](https://npmjs.com/package/cordova-plugin-screen-orientation), and ensured both were not working when tested in Android version 10.