### PR TITLE
[FET-1012] Fix: Add validation to input

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -16,7 +16,3 @@ export async function loadPlates(): Promise<void> {
   state.plates = plates ? plates?.map(plate => ({ ...plate, answer: null })) : null;
   preRenderFirstPlateImage(state.plates[0].url);
 }
-
-export function assertOnlyAlphanumericChars(value: string): boolean {
-  return /^[a-zA-Z0-9]+$/.test(value);
-}

--- a/src/pages/slider/slider.css
+++ b/src/pages/slider/slider.css
@@ -27,6 +27,9 @@
   margin-bottom: 10px;
 }
 
+ion-input {
+  margin-bottom: 0;
+}
 
 @media only screen and (max-width: 390px) {
   .swiper-slide img {

--- a/src/types/slider.ts
+++ b/src/types/slider.ts
@@ -2,3 +2,8 @@ export enum SlideChangeDirection {
   Previous = 'prev',
   Next = 'next',
 }
+
+export type SliderInputState = {
+  isValid: boolean;
+  isDirty: boolean;
+};


### PR DESCRIPTION
It is not possible to remove non-alphanumeric characters from the keyboard displayed to the user. The next best thing is to:
- Show validation errors when non-alphanumeric characters are entered.
- Disable the "next"/"finish" button if the input contains non-alphanumeric characters.
- Disable swiping right to the next slide if the input contains non-alphanumeric characters