### PR TITLE
[FET-1049]: Ishihara redesign challenge

### DIFF
--- a/src/pages/landing/landing.tsx
+++ b/src/pages/landing/landing.tsx
@@ -18,13 +18,13 @@ export class LandingPage {
     return (
       <app-layout hasBack={false}>
         <div class="ion-padding">
-          <h2 data-testid="landing-page-title">Ishihara Color Blindness Test</h2>
+          <h2 data-testid="landing-page-title">Ishihara Plates Challenge</h2>
           <div class="container">
             <img data-testid="landing-page-image" src="/assets/images/cover-isihara.png" alt="Ishihara" />
           </div>
-          <h3 data-testid="landing-page-caption">Optometry Color Deficiency Test</h3>
+          <h3 data-testid="landing-page-caption">Challenge</h3>
           <p data-testid="landing-page-text">
-            The Ishihara test is a color perception test for color deficiencies, the first in a class of successful color vision tests called pseudo-isochromatic plates
+          Ishihara is an experimental app and not a substitute for medical diagnosis, advice, or treatment.
           </p>
           <app-button
             dataTestId="landing-page-btn"

--- a/src/pages/result/result.tsx
+++ b/src/pages/result/result.tsx
@@ -49,9 +49,9 @@ export class ResultPage {
     return (
       <app-layout>
         <div class="ion-padding">
-          <h2>Color Deficiency Test Report</h2>
+          <h2>Final Report</h2>
           <div class="result">
-            <h3>Test result</h3>
+            <h3>Challenge Result</h3>
             <p data-testid="percentage">
               {this.correctPlates.length}/{state.plates.length} ({this.scorePercentage}%)
             </p>

--- a/src/pages/slider/slider.tsx
+++ b/src/pages/slider/slider.tsx
@@ -172,7 +172,7 @@ export class SliderPage {
     return (
       <app-layout>
         <div class="ion-padding">
-          <h2>Color Deficiency Test</h2>
+          <h2>Ishihara Plates Challenge</h2>
           <ion-slides
             options={this.slideOpts}
             onIonSlideNextStart={this.handleSlideChange.bind(this, SlideChangeDirection.Next)}


### PR DESCRIPTION
- On the loading page, where it says “Optometry Color Deficiency Test” it is now “Challenge";
- On the landing page, where it was “Ishihara Color Blindness Test” it is now “Ishihara Plates Challenge”;
- On the plates slider, where it was “Color Deficiency Test” is now “Ishihara Plates Challenge”;
- On the results page, where it was “Color Deficiency Test Report” is now “Final Report”;
- On the results page, where it was “Test Result” is now “Challenge Result”;